### PR TITLE
Implement product and store modules with Prisma

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",
     "@nestjs/platform-express": "^10.2.5",
+    "@nestjs/swagger": "^7.1.9",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from './prisma.service';
 import { ProductModule } from './product/product.module';
 import { StoreModule } from './store/store.module';
 
 @Module({
   imports: [ProductModule, StoreModule],
-  providers: [PrismaService],
 })
 export class AppModule {}

--- a/apps/api/src/product/product.controller.ts
+++ b/apps/api/src/product/product.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, ParseIntPipe } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { Prisma } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('products')
 @Controller('products')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
@@ -14,5 +16,10 @@ export class ProductController {
   @Get()
   findAll() {
     return this.productService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.productService.findOne(id);
   }
 }

--- a/apps/api/src/product/product.module.ts
+++ b/apps/api/src/product/product.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductController } from './product.controller';
+import { PrismaService } from '../prisma.service';
 
 @Module({
   controllers: [ProductController],
-  providers: [ProductService],
+  providers: [ProductService, PrismaService],
 })
 export class ProductModule {}

--- a/apps/api/src/product/product.service.ts
+++ b/apps/api/src/product/product.service.ts
@@ -13,4 +13,16 @@ export class ProductService {
   findAll(): Promise<Product[]> {
     return this.prisma.product.findMany();
   }
+
+  findOne(id: number): Promise<Product | null> {
+    return this.prisma.product.findUnique({ where: { id } });
+  }
+
+  update(id: number, data: Prisma.ProductUpdateInput): Promise<Product> {
+    return this.prisma.product.update({ where: { id }, data });
+  }
+
+  remove(id: number): Promise<Product> {
+    return this.prisma.product.delete({ where: { id } });
+  }
 }

--- a/apps/api/src/store/store.controller.ts
+++ b/apps/api/src/store/store.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, ParseIntPipe } from '@nestjs/common';
 import { StoreService } from './store.service';
 import { Prisma } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('stores')
 @Controller('stores')
 export class StoreController {
   constructor(private readonly storeService: StoreService) {}
@@ -14,5 +16,10 @@ export class StoreController {
   @Get()
   findAll() {
     return this.storeService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.storeService.findOne(id);
   }
 }

--- a/apps/api/src/store/store.module.ts
+++ b/apps/api/src/store/store.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { StoreService } from './store.service';
 import { StoreController } from './store.controller';
+import { PrismaService } from '../prisma.service';
 
 @Module({
   controllers: [StoreController],
-  providers: [StoreService],
+  providers: [StoreService, PrismaService],
 })
 export class StoreModule {}

--- a/apps/api/src/store/store.service.ts
+++ b/apps/api/src/store/store.service.ts
@@ -13,4 +13,16 @@ export class StoreService {
   findAll(): Promise<Store[]> {
     return this.prisma.store.findMany();
   }
+
+  findOne(id: number): Promise<Store | null> {
+    return this.prisma.store.findUnique({ where: { id } });
+  }
+
+  update(id: number, data: Prisma.StoreUpdateInput): Promise<Store> {
+    return this.prisma.store.update({ where: { id }, data });
+  }
+
+  remove(id: number): Promise<Store> {
+    return this.prisma.store.delete({ where: { id } });
+  }
 }


### PR DESCRIPTION
## Summary
- extend Product and Store services with CRUD
- add Swagger tags and routes for fetching by id
- provide PrismaService within respective modules
- expose ProductModule and StoreModule via AppModule
- add `@nestjs/swagger` dependency for API documentation

## Testing
- `pnpm --filter api build` *(fails: nest not found as dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d4537b4b88326bed296586f361307